### PR TITLE
Alphabetize shuls list on homepage

### DIFF
--- a/src/main/java/com/tbdev/teaneckminyanim/service/ZmanimService.java
+++ b/src/main/java/com/tbdev/teaneckminyanim/service/ZmanimService.java
@@ -200,8 +200,9 @@ public class ZmanimService {
         mv.getModel().put("kolminyanim", kolhaMinyanims);
         Stream<KolhaMinyanim> stream = kolhaMinyanims.stream();
 
-        // Get the unique values based on the 'organizationId' property
+        // Get unique shuls (deduplicated by org), sorted alphabetically by name
         List<KolhaMinyanim> uniqueKolhaMinyanims = stream.filter(distinctByKey(KolhaMinyanim::getOrganizationId))
+                .sorted(Comparator.comparing(k -> k.getOrganizationName().toLowerCase()))
                 .collect(Collectors.toList());
 
         mv.getModel().put("uniqueKolhaMinyanims", uniqueKolhaMinyanims);


### PR DESCRIPTION
## Summary
- Sorts the unique organizations list (Shuls section on homepage) alphabetically by name, case-insensitive
- Previously ordered by the first minyan's start time, which was arbitrary from a user's perspective

Closes #56

## Test plan
- [ ] Homepage Shuls section shows organizations in A–Z order

🤖 Generated with [Claude Code](https://claude.com/claude-code)