### PR TITLE
Fix: dynamic zmanim using Jerusalem fallback instead of Teaneck (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-03-15
+
+### Fixed
+- **Critical: dynamic zmanim showing wrong times (#141)** — `TimeRule.getTime()` was instantiating a bare `ZmanimHandler()` that fell back to Jerusalem, Israel coordinates. A "Shkiya" minyan therefore computed sunset for Jerusalem (~6 PM Israel time = ~11 AM New York time) instead of Teaneck. Fixed by adding `MinyanTime.resolveLocalTime()` which accepts a properly-configured zmanim supplier from `CalendarMaterializationService`; the supplier uses the injected `ZmanimHandler` bean (Teaneck coordinates). The legacy `TimeRule.getTime()` code path is preserved for non-materialization use cases.
+
 ## [1.8.0] - 2026-03-15
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>  
   <groupId>com.tbdev</groupId>  
   <artifactId>Teaneck-Minyanim</artifactId>  
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <name>Teaneck-Minyanim</name>
   <description>Teaneck-Minyanim</description>
   <properties>

--- a/src/main/java/com/tbdev/teaneckminyanim/minyan/MinyanTime.java
+++ b/src/main/java/com/tbdev/teaneckminyanim/minyan/MinyanTime.java
@@ -3,6 +3,14 @@ import com.kosherjava.zmanim.util.Time;
 import com.tbdev.teaneckminyanim.enums.Zman;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.WeekFields;
+import java.util.Date;
+import java.util.Dictionary;
+import java.util.Locale;
+import java.util.function.Function;
 
 public class MinyanTime {
     private Time time;
@@ -311,6 +319,69 @@ public class MinyanTime {
             return rule.getTime(date);
         } else {
             return null;
+        }
+    }
+
+    /**
+     * Resolve this MinyanTime to a {@link LocalTime} using a correctly-configured
+     * zmanim supplier (avoids the bug in {@link TimeRule#getTime} which instantiates
+     * a bare {@code ZmanimHandler} that falls back to Jerusalem coordinates).
+     *
+     * <p>For FIXED times the supplier is never called; the stored hours/minutes are
+     * used directly.  For DYNAMIC/ROUNDED the supplier is invoked to get the
+     * correctly-computed {@link Date} for the required {@link Zman}, which is then
+     * converted to a {@link LocalTime} in the given timezone.</p>
+     *
+     * @param zmanimSupplier maps a date to the pre-computed zmanim dictionary
+     * @param date           the calendar date being materialized
+     * @param zoneId         the application timezone (America/New_York)
+     * @return the resolved start time, or {@code null} if this is NONE or data is missing
+     */
+    public LocalTime resolveLocalTime(
+            Function<LocalDate, Dictionary<Zman, Date>> zmanimSupplier,
+            LocalDate date,
+            ZoneId zoneId) {
+
+        switch (type()) {
+            case FIXED: {
+                if (time == null) return null;
+                int h = time.getHours();
+                int m = time.getMinutes();
+                // Mirror the rounding logic used in displayTime()
+                if (time.getSeconds() > 30) m++;
+                if (m >= 60) { h++; m -= 60; }
+                return LocalTime.of(h, m, 0);
+            }
+            case DYNAMIC: {
+                if (rule == null) return null;
+                Date zmanDate = zmanimSupplier.apply(date).get(rule.getZman());
+                if (zmanDate == null) return null;
+                return zmanDate.toInstant()
+                        .atZone(zoneId)
+                        .toLocalTime()
+                        .plusMinutes(rule.getOffsetMinutes())
+                        .truncatedTo(ChronoUnit.MINUTES);
+            }
+            case ROUNDED: {
+                if (rule == null) return null;
+                // Find the earliest occurrence of this zman across Sun–Fri of the week
+                LocalTime minTime = null;
+                for (int dow = 1; dow <= 6; dow++) {
+                    LocalDate day = date.with(WeekFields.of(Locale.US).dayOfWeek(), dow);
+                    Date dayZmanDate = zmanimSupplier.apply(day).get(rule.getZman());
+                    if (dayZmanDate != null) {
+                        LocalTime t = dayZmanDate.toInstant().atZone(zoneId).toLocalTime();
+                        if (minTime == null || t.isBefore(minTime)) minTime = t;
+                    }
+                }
+                if (minTime == null) return null;
+                LocalTime withOffset = minTime.plusMinutes(rule.getOffsetMinutes());
+                // Round down to nearest 5 minutes
+                int minute = (withOffset.getMinute() / 5) * 5;
+                return withOffset.withMinute(minute).withSecond(0).withNano(0);
+            }
+            default:
+                return null;
         }
     }
 }

--- a/src/main/java/com/tbdev/teaneckminyanim/service/CalendarMaterializationService.java
+++ b/src/main/java/com/tbdev/teaneckminyanim/service/CalendarMaterializationService.java
@@ -1,6 +1,5 @@
 package com.tbdev.teaneckminyanim.service;
 
-import com.kosherjava.zmanim.util.Time;
 import com.tbdev.teaneckminyanim.enums.EventSource;
 import com.tbdev.teaneckminyanim.minyan.MinyanTime;
 import com.tbdev.teaneckminyanim.minyan.MinyanType;
@@ -13,11 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -128,18 +125,16 @@ public class CalendarMaterializationService {
             // For each minyan, check if it has a service on this date
             for (Minyan minyan : minyanim) {
                 try {
-                    // Get the start time for this date based on the minyan's schedule
-                    Date startDateTime = minyan.getStartDate(date);
                     MinyanTime minyanTime = minyan.getMinyanTime(date);
-                    
-                    if (startDateTime != null && minyanTime != null) {
-                        Time time = minyanTime.getTime(date);
-                        
-                        if (time != null) {
-                            // Convert Date to LocalTime
-                            LocalTime startTime = startDateTime.toInstant()
-                                    .atZone(zoneId)
-                                    .toLocalTime();
+
+                    if (minyanTime != null) {
+                        // Use resolveLocalTime with the properly-configured zmanimHandler.
+                        // This avoids the bug in TimeRule.getTime() which creates its own
+                        // ZmanimHandler() that falls back to Jerusalem coordinates.
+                        LocalTime startTime = minyanTime.resolveLocalTime(
+                                zmanimHandler::getZmanim, date, zoneId);
+
+                        if (startTime != null) {
                             
                             // Get location details
                             String locationId = minyan.getLocationId();


### PR DESCRIPTION
## Root Cause

`TimeRule.getTime()` called `new ZmanimHandler()` — the no-arg constructor that **falls back to Jerusalem, Israel** (`31.77°N, 35.21°E`) when `ApplicationSettingsService` is not injected. All dynamic/rounded zmanim-based minyanim (Shkiya, Netz, Plag HaMincha, etc.) were therefore computed for Jerusalem, not Teaneck.

**Example:** A minyan at "Shkiya" (sunset):
- Jerusalem sunset March 15 ≈ 6:03 PM Israel time (UTC+2) = **11:03 AM New York time** ✗
- Teaneck sunset March 15 ≈ 7:03 PM New York time ✓

This explains the screenshot in #141 showing a Shkiya minyan at 11:35 AM.

## Fix

Added `MinyanTime.resolveLocalTime(zmanimSupplier, date, zoneId)` — a new method that accepts a `Function<LocalDate, Dictionary<Zman, Date>>` instead of creating its own `ZmanimHandler`. 

`CalendarMaterializationService.generateRulesEvents()` now calls this method with `zmanimHandler::getZmanim` (the properly-configured Spring bean using Teaneck coordinates), bypassing the broken `TimeRule.getTime()` path entirely.

The legacy `TimeRule.getTime()` is left untouched for any other callers.

## After Merging

Trigger a full re-materialization from the admin panel:
**Admin → Calendar Events → Re-materialize All**

This will rebuild all `RULES` events with the corrected zmanim times.

## Test Plan
- [ ] Deploy and trigger re-materialization
- [ ] Verify a Shkiya minyan shows the correct sunset time for Teaneck
- [ ] Verify a Netz minyan shows the correct sunrise time
- [ ] Verify fixed-time minyanim are unchanged
- [ ] Verify Plag HaMincha and other dynamic zmanim are correct

Closes #141