### PR TITLE
Fix #177: notification tap opens ShulDaySheet; hide bell within 10 min

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -36,7 +36,8 @@ import { useSchedule, useZmanim, useOrganizations } from '@/api/hooks';
 import { toApiDate } from '@/api/client';
 import type { ScheduleEvent, Organization } from '@/api/types';
 import { formatTime } from '@/utils/time';
-import { registerScrollToNow, unregisterScrollToNow, registerGoToday, unregisterGoToday } from '@/utils/tabEvents';
+import { registerScrollToNow, unregisterScrollToNow, registerGoToday, unregisterGoToday, registerOpenSheet, unregisterOpenSheet } from '@/utils/tabEvents';
+import type { SheetTarget } from '@/utils/tabEvents';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -306,6 +307,35 @@ export default function MinyanimScreen() {
     registerGoToday(goToday);
     return () => { unregisterScrollToNow(); unregisterGoToday(); };
   }, [scrollToNow, goToday]);
+
+  // Open ShulDaySheet when a notification is tapped
+  useEffect(() => {
+    registerOpenSheet((target: SheetTarget) => {
+      setSelectedDate(target.date);
+      setSheetEvent({
+        id: target.eventId,
+        date: target.date,
+        startTime: '',
+        minyanType: '',
+        minyanTypeDisplay: '',
+        locationName: null,
+        notes: null,
+        nusach: null,
+        nusachDisplay: null,
+        dynamicTimeString: null,
+        source: 'RULES',
+        whatsapp: null,
+        organization: {
+          id: target.orgSlug,
+          slug: target.orgSlug,
+          name: target.orgName,
+          color: colors.tint,
+          whatsapp: null,
+        },
+      });
+    });
+    return () => unregisterOpenSheet();
+  }, []);
 
   // Show FAB only on today, when scrolled >300px from the NOW divider
   const showJump = isToday && !isLoading && nowYRef.current >= 0 &&

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -2,8 +2,9 @@ import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import 'react-native-reanimated';
+import { router } from 'expo-router';
 import { QueryClient } from '@tanstack/react-query';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
@@ -12,6 +13,7 @@ import * as Notifications from 'expo-notifications';
 
 import { useColorScheme } from '@/components/useColorScheme';
 import { requestNotificationPermission, SNOOZE_ACTION } from '@/utils/notifications';
+import { triggerOpenSheet } from '@/utils/tabEvents';
 
 export { ErrorBoundary } from 'expo-router';
 
@@ -55,6 +57,38 @@ export default function RootLayout() {
   // Request notification permission early so reminders work immediately
   useEffect(() => {
     requestNotificationPermission();
+  }, []);
+
+  // Handle notification tap: navigate to minyanim tab and open the ShulDaySheet
+  // Use a ref so we can call triggerOpenSheet after navigation settles
+  const pendingSheetRef = useRef<Parameters<typeof triggerOpenSheet>[0] | null>(null);
+  useEffect(() => {
+    const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+      if (response.actionIdentifier !== Notifications.DEFAULT_ACTION_IDENTIFIER) return;
+      const data = response.notification.request.content.data as {
+        eventId?: string;
+        date?: string;
+        orgSlug?: string;
+        orgName?: string;
+      };
+      if (!data.eventId || !data.date || !data.orgSlug) return;
+      pendingSheetRef.current = {
+        eventId: data.eventId,
+        date: data.date,
+        orgSlug: data.orgSlug,
+        orgName: data.orgName ?? '',
+      };
+      // Navigate to minyanim tab first; index.tsx will consume pendingSheetRef
+      router.navigate('/(tabs)/');
+      // Give the tab a frame to mount/focus before triggering the sheet
+      setTimeout(() => {
+        if (pendingSheetRef.current) {
+          triggerOpenSheet(pendingSheetRef.current);
+          pendingSheetRef.current = null;
+        }
+      }, 300);
+    });
+    return () => sub.remove();
   }, []);
 
   // Handle snooze action: reschedule the same notification 5 minutes later

--- a/mobile/components/MinyanCard.tsx
+++ b/mobile/components/MinyanCard.tsx
@@ -53,13 +53,17 @@ export default function MinyanCard({
   const now = new Date();
   const localNow = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}T${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
   const isPastEvent = `${event.date}T${event.startTime}` < localNow;
+  // Hide bell when <10 min away — we can't deliver a 10-min reminder that late
+  const minyanMs = new Date(`${event.date}T${event.startTime}:00`).getTime();
+  const tooSoonToRemind = minyanMs - now.getTime() < 10 * 60 * 1000;
+  const showBell = !isPastEvent && !tooSoonToRemind;
 
   useEffect(() => {
-    if (isPastEvent) return;
+    if (!showBell) return;
     let cancelled = false;
     isReminderSet(event.id).then((v) => { if (!cancelled) setReminderSet(v); });
     return () => { cancelled = true; };
-  }, [event.id, isPastEvent]);
+  }, [event.id, showBell]);
 
   const toggleReminder = useCallback(async () => {
     if (reminderSet) {
@@ -69,6 +73,7 @@ export default function MinyanCard({
       const id = await scheduleReminder({
         eventId: event.id,
         orgName: event.organization?.name ?? '',
+        orgSlug: event.organization?.slug ?? event.organization?.id ?? '',
         minyanType: event.minyanTypeDisplay,
         startTime: event.startTime,
         date: event.date,
@@ -112,8 +117,8 @@ export default function MinyanCard({
             <Text style={[styles.time, { color: colors.text }]}>
               {formatTime(event.startTime)}
             </Text>
-            {/* Reminder bell — hidden for past events */}
-            {!isPastEvent && (
+            {/* Reminder bell — hidden for past events or within 10 min */}
+            {showBell && (
               <TouchableOpacity onPress={toggleReminder} hitSlop={10} style={styles.bellBtn}>
                 <SymbolView
                   name={reminderSet ? 'bell.fill' : 'bell'}

--- a/mobile/utils/notifications.ts
+++ b/mobile/utils/notifications.ts
@@ -48,6 +48,7 @@ async function setupReminderCategory() {
 export interface ReminderOptions {
   eventId: string;         // used as the notification identifier for deduplication
   orgName: string;
+  orgSlug: string;
   minyanType: string;
   startTime: string;       // "HH:mm"
   date: string;            // "YYYY-MM-DD"
@@ -86,6 +87,8 @@ export async function scheduleReminder(opts: ReminderOptions): Promise<string | 
         eventId: opts.eventId,
         date: opts.date,
         minyanType: opts.minyanType,
+        orgSlug: opts.orgSlug,
+        orgName: opts.orgName,
         // originalTitle kept for backwards compat with any previously scheduled notifications
         originalTitle: `${opts.minyanType} in ${minutesBefore} minutes`,
         originalBody: `${opts.orgName} · ${formatDisplayTime(opts.startTime)}`,

--- a/mobile/utils/tabEvents.ts
+++ b/mobile/utils/tabEvents.ts
@@ -10,3 +10,17 @@ export function triggerScrollToNow() { _scrollToNow?.(); }
 export function registerGoToday(fn: Callback) { _goToday = fn; }
 export function unregisterGoToday() { _goToday = null; }
 export function triggerGoToday() { _goToday?.(); }
+
+// Open the ShulDaySheet from a notification tap
+export interface SheetTarget {
+  eventId: string;
+  date: string;
+  orgSlug: string;
+  orgName: string;
+}
+
+let _openSheet: ((target: SheetTarget) => void) | null = null;
+
+export function registerOpenSheet(fn: (target: SheetTarget) => void) { _openSheet = fn; }
+export function unregisterOpenSheet() { _openSheet = null; }
+export function triggerOpenSheet(target: SheetTarget) { _openSheet?.(target); }


### PR DESCRIPTION
## Summary
- Tapping a minyan reminder notification navigates to the minyanim tab and opens the `ShulDaySheet` for that org's schedule that day, with the notified minyan highlighted and scrolled into view — same UX as tapping a card directly
- Adds `orgSlug` and `orgName` to the notification data payload so the sheet can open without an extra API roundtrip
- Adds `openSheet` event to `tabEvents.ts` for cross-component signalling from `_layout.tsx` → `index.tsx`
- Hides the reminder bell when within 10 minutes of the minyan start time, since a 10-minute notification can't be delivered at that point

## Test plan
- [ ] Schedule a reminder for a minyan >10 min away — bell appears
- [ ] Wait until <10 min before — bell disappears
- [ ] Tap a notification → lands on minyanim tab, ShulDaySheet slides up showing that org's day schedule with the notified minyan highlighted
- [ ] Snooze action still works (reschedules 5 min later, sheet does not open)
- [ ] Notification tap works when app is in background and when app is closed (cold start)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)