### PR TITLE
Expand ShulDaySheet swipe-to-dismiss zone to full header area

### DIFF
--- a/mobile/components/ShulDaySheet.tsx
+++ b/mobile/components/ShulDaySheet.tsx
@@ -82,7 +82,9 @@ export default function ShulDaySheet({ event, date, onClose }: Props) {
 
   const dismissPan = useRef(
     PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
+      // Use onMove (not onStart) so taps on the ✕ close button still fire
+      onMoveShouldSetPanResponder: (_, gs) =>
+        gs.dy > 5 && Math.abs(gs.dy) > Math.abs(gs.dx),
       onPanResponderMove: (_, gs) => {
         if (gs.dy > 0) translateY.setValue(gs.dy);
       },
@@ -117,27 +119,28 @@ export default function ShulDaySheet({ event, date, onClose }: Props) {
             styles.sheet,
             { backgroundColor: colors.card, transform: [{ translateY }] },
           ]}>
-          {/* Drag handle */}
-          <View style={styles.handleArea} {...dismissPan.panHandlers}>
-            <View style={[styles.handle, { backgroundColor: colors.border }]} />
-          </View>
-
-          {/* Header: org color bar + name + date */}
-          <View style={[styles.headerBar, { backgroundColor: orgColor }]} />
-          <View style={[styles.header, { borderBottomColor: colors.border }]}>
-            <View style={styles.headerContent}>
-              <Text style={[styles.orgName, { color: colors.text }]} numberOfLines={1}>
-                {orgName}
-              </Text>
-              {parsedDate ? (
-                <Text style={[styles.dateLabel, { color: colors.textSecondary }]}>
-                  {format(parsedDate, 'EEEE, MMMM d')}
-                </Text>
-              ) : null}
+          {/* Drag zone: handle + color bar + header row — all swipe-to-dismiss */}
+          <View {...dismissPan.panHandlers}>
+            <View style={styles.handleArea}>
+              <View style={[styles.handle, { backgroundColor: colors.border }]} />
             </View>
-            <TouchableOpacity onPress={dismiss} hitSlop={10} style={styles.closeBtn}>
-              <Text style={[styles.closeText, { color: colors.textTertiary }]}>✕</Text>
-            </TouchableOpacity>
+
+            <View style={[styles.headerBar, { backgroundColor: orgColor }]} />
+            <View style={[styles.header, { borderBottomColor: colors.border }]}>
+              <View style={styles.headerContent}>
+                <Text style={[styles.orgName, { color: colors.text }]} numberOfLines={1}>
+                  {orgName}
+                </Text>
+                {parsedDate ? (
+                  <Text style={[styles.dateLabel, { color: colors.textSecondary }]}>
+                    {format(parsedDate, 'EEEE, MMMM d')}
+                  </Text>
+                ) : null}
+              </View>
+              <TouchableOpacity onPress={dismiss} hitSlop={10} style={styles.closeBtn}>
+                <Text style={[styles.closeText, { color: colors.textTertiary }]}>✕</Text>
+              </TouchableOpacity>
+            </View>
           </View>
 
           {/* Events list */}


### PR DESCRIPTION
## Summary
Previously the swipe-to-dismiss gesture on the minyan card bottom sheet only worked on the tiny drag handle pill. The user had to precisely hit a ~36×4px target to initiate a dismiss swipe.

This PR expands the swipe zone to the entire top section — drag handle + org color bar + shul name/date header row — matching the area the user naturally grabs to pull the sheet down.

**Also:** switched from `onStartShouldSetPanResponder` to `onMoveShouldSetPanResponder` (with a directional guard) so taps on the ✕ close button still fire correctly through the swipe zone.

## Test plan
- [ ] Open a minyan card sheet, swipe down from the handle → dismisses
- [ ] Swipe down from the shul name/date area → dismisses  
- [ ] Swipe down from the color bar → dismisses
- [ ] Tap the ✕ close button → dismisses (not blocked by pan responder)
- [ ] Tap the ✕ button without swiping → should not trigger a dismiss swipe first

🤖 Generated with [Claude Code](https://claude.com/claude-code)